### PR TITLE
Increase patch version number to 7.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+# 7.0.1
+## 2021-03-11
+* #67 Run docker with group permissions of the user executing the pipeline
+* #65 Check for write permission on output directories before executing
+
+# 7.0.0
+## 2021-03-02
+* #43 Port to DSL2

--- a/pipeline/config/methods.config
+++ b/pipeline/config/methods.config
@@ -5,7 +5,7 @@ manifest {
     name = "align-DNA"
     author = "Benjamin Carlin; Chenghao Zhu; Aaron Holmes"
     description = "alignment pipeline for paired fastqs DNA samples"
-    version = "7.0.0"
+    version = "7.0.1"
     }
 
 params {


### PR DESCRIPTION
* Directory check is not a breaking change because pipeline would fail
  without the check regardless
* Docker group ID change is not a breaking change because permissions
  would prevent the job from running regardless
  * Note that this is _not_ true for some users executing this pipeline
    manually

I also added a changelog file.