### PR TITLE
Check node configurations by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ After marking dup BAM files, the BAM files are then indexed by utilizing Picard 
 | `blcds_patient_id` | no | string | The registered patient ID of this sample from the Boutros Lab data registry. Ignored if `blcds_registered_data_input = true` or `blcds_registered_output = false` |
 | `blcds_sample_id` | no | string | The registered sample ID from the Boutros Lab data registry. Ignored if `blcds_registered_data_input = true` or `blcds_registered_output = false` |
 | `blcds_mount_dir` | no | string | The directoyr that the storage is mounted to (e.g., /hot, /data). |
+| `check_node_config` | no | boolean | Whether to check pre-configured node settings used to set CPU and memory constraints. The default behavior, whether `true` or undefined is to check the pre-configured node settings. Set to `false` to skip this check. |
 
 ---
 

--- a/pipeline/config/methods.config
+++ b/pipeline/config/methods.config
@@ -205,7 +205,9 @@ methods {
         methods.set_trace()
         methods.set_report()
         methods.set_docker_sudo()
-        if (params.check_node_config) {
+
+        // The default behavior (if the key is undefined or true) is to use the pre-configured node settings.
+        if (!params.containsKey('check_node_config') || params.check_node_config) {
             methods.set_node_config()
             }
         else {

--- a/pipeline/nextflow.example.config
+++ b/pipeline/nextflow.example.config
@@ -27,7 +27,7 @@ params {
     // set to true to redirect output files directly to the Boutros Lab data storage.
     blcds_registered_dataset_output = false
 
-    // uncooment the following in order to save output bam and log directly to blcds data storage
+    // uncomment the following in order to save output bam and log directly to blcds data storage
     // blcds_cluster_slurm = true
     // blcds_disease_id = "disease_id"
     // blcds_dataset_id = "dataset_id"
@@ -37,8 +37,9 @@ params {
     // blcds_technology = "WGS"
     // blcds_mount_dir = "/data"
 
-    // set to false for testing on nodes that don't match the
-    // pre-configured lowmem/midmem/execute nodes
+    // Set to false for testing on nodes that don't match the
+    // pre-configured lowmem/midmem/execute nodes.
+    // Removing this variable has the same effect as setting it to `true`.
     check_node_config = true
     }
 


### PR DESCRIPTION
* Fixes crash when `check_node_config` is not defined
* Default behavior is to act as if the variable is `true` when it is undefined
* Documented the variable in Inputs

Closes #70