### PR TITLE
fixed issue #89 that docker permission is not set properly

### DIFF
--- a/pipeline/config/methods.config
+++ b/pipeline/config/methods.config
@@ -216,10 +216,10 @@ methods {
             throw new Exception('ERROR: lowmem cannot be used for align-DNA.')
             }
         else if (node_cpus == 72 && (node_mem == '136.8 GB' || node_mem == '141.7 GB')) {
-            includeConfig "${projectDir}/config/midmem.config"
+            includeConfig 'config/midmem.config'
             }
         else if (node_cpus == 64 && (node_mem == '950 GB' || node_mem == '1007.9 GB')) {
-            includeConfig "${projectDir}/config/execute.config"
+            includeConfig 'config/execute.config'
             }
         else {
             throw new Exception('ERROR: System resources not as expected, unable to assign resources.')


### PR DESCRIPTION
Seems like the issue was that originally `docker._uid_and_gid` and `docker._all_group_ids` were both defined as closer, so `docker.runOptions` became an empty string.

Closes #89 