### PR TITLE
Fix bug when only running hisat2

### DIFF
--- a/pipeline/config/methods.config
+++ b/pipeline/config/methods.config
@@ -30,11 +30,13 @@ if (!params.containsKey('check_node_config')) {
     params.check_node_config = true
     }
 
-if (!params.reference_fasta_index_files_bwa) {
-    params.reference_fasta_index_files_bwa = "${params.reference_fasta_bwa}.*"
-    }
-if (!params.reference_fasta_index_files_bwa) {
-    params.reference_fasta_index_files_bwa = "${params.reference_fasta_bwa}.fai"
+if (params.aligner.contains("BWA-MEM2")) {
+    if (!params.reference_fasta_index_files_bwa) {
+        params.reference_fasta_index_files_bwa = "${params.reference_fasta_bwa}.*"
+        }
+    if (!params.reference_fasta_index_files_bwa) {
+        params.reference_fasta_index_files_bwa = "${params.reference_fasta_bwa}.fai"
+        }   
     }
 
 if (params.hisat2_index_prefix) {


### PR DESCRIPTION
When only using hisat2, reference_fasta_bwa is not defined which causes an error in methods.config. I added a conditional statement around the section to avoid that.