### PR TITLE
fixed method connfig to not check HISAT2 index when it is not used

### DIFF
--- a/pipeline/config/methods.config
+++ b/pipeline/config/methods.config
@@ -39,7 +39,7 @@ if (params.aligner.contains("BWA-MEM2")) {
         }   
     }
 
-if (params.hisat2_index_prefix) {
+if (params.aligner.contains('HISAT2')) {
     params.reference_fasta_index_files_hisat2 = "${params.hisat2_index_prefix}.*.ht2"
     }
 


### PR DESCRIPTION
This is to fix a bug reported in #122 that when HISAT2 isn't specified, it still trys to access the`params.hisat2_index_prefix` variables, which should be undefined.

Closes #122 