### PR TITLE
Edit readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ python path/to/pipeline-align-DNA/script/write_dna_align_config_file.py \
 	/hot/ref/hg38/bwa-mem2/v2.1/genome.fa \
 	/my/path/to/output_directory \
 	/my/path/to/temp_directory \
-	--save_intermediate_files --cache_intermediate_pipeline_steps
+	--save_intermediate_files \
+	--cache_intermediate_pipeline_steps
 ```
 ---
 


### PR DESCRIPTION
I added to the README a few sentences about the usage of the python script to create a config file. 

Should we give a docker image for that? I have one that I created to run these kinds of scripts on the cluster, because docopt is not installed in there.
