### PR TITLE
Update bam index file extension to .bam.bai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 - Update `.gitignore` file according to [template] (https://github.com/uclahs-cds/template-NextflowPipeline/blob/main/.gitignore)
 - Standardize output and log directory structure
+- Update index file extension from all processes to .bam.bai 
 
 ## [7.3.1] - 2022-01-14
 ### Changed

--- a/pipeline/modules/check_512sum.nf
+++ b/pipeline/modules/check_512sum.nf
@@ -2,7 +2,10 @@
 process Generate_Sha512sum {    
    container params.docker_image_sha512sum
 
-   publishDir path: "${checksum_output_dir}", mode: 'copy'
+   publishDir path: "${checksum_output_dir}",
+      mode: "copy",
+      pattern: "*.sha512",
+      saveAs: { filename -> (filename.endsWith(".bai.sha512") && !filename.endsWith(".bam.bai.sha512")) ? "${file(file(filename).baseName).baseName}.bam.bai.sha512" : "${filename}"}
 
    input:
       file(input_file)

--- a/pipeline/modules/mark_duplicate_picardtools.nf
+++ b/pipeline/modules/mark_duplicate_picardtools.nf
@@ -6,7 +6,8 @@ process run_MarkDuplicate_Picard {
 
    publishDir path: "${bam_output_dir}",
       pattern: "*.{bam,bai}",
-      mode: 'copy'
+      mode: 'copy',
+      saveAs: { filename -> (file(filename).getExtension() == "bai") ? "${file(filename).baseName}.bam.bai" : "${filename}" }
 
    publishDir path: "${qc_output_dir}/${task.process.split(':')[1].replace('_', '-')}",
       pattern: "*.metrics",


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/pages/viewpage.action?pageId=84091668).

- [X] I have set up the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request, or the branch protection rule has already been set up.

- [X] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the config as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [X] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and config file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [X] I have tested the pipeline on at least one A-mini sample with aligner setting to `BWA-MEM2`, `HISAT2`, and both. The paths to the test config files and output directories were attached below.

<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Closes #170 
Updated the Mark_Duplicate_Picard process to output save bam index files in the correct file extension format (`.bam` -> `.bam.bai`).
Also adjusted the checksum filename accordingly (`.bai.sha512` -> `.bam.bai.sha512`)

**Test Results**

- BWA-MEM2 & HISAT2
	- sample:    A-mini, multiple libraries & lanes 
	- input csv: /hot/users/nzeltser/pipeline-align-DNA/pipeline/run_test/inputs/a_mini_multiple_libs.csv
	- config:    /hot/users/nzeltser/pipeline-align-DNA/pipeline/run_test/config/a_mini_multiple_libs.config
	- output:   /hot/pipeline/development/slurm/align-DNA/unreleased/nzeltser-update-index-extension/

mark_duplicates == false: /no-mark-duplicates/
enable_spark == false: /spark-disabled/
enable_spark == true; /spark-enabled/
