### PR TITLE
try testing samtools sort memory

### DIFF
--- a/test/memory-samtools-sort/test-memory-samtools-sort.sh
+++ b/test/memory-samtools-sort/test-memory-samtools-sort.sh
@@ -16,11 +16,11 @@ input_bam=a_mini_n1.bam;
 sort_order="-n";
 bam_output_filename=${input_bam}.sorted;
 
-#docker run \
-#    -v ${path_input_bam}:${path_input_bam} \
-#    -v ${path_out}:${path_out} \
-#    -w ${path_out} \
-#    blcdsdockerregistry/samtools:1.15.1 \
+docker run -u $(id -u):$(id -g) \
+    -v ${path_input_bam}:${path_input_bam} \
+    -v ${path_out}:${path_out} \
+    -w ${path_out} \
+    blcdsdockerregistry/samtools:1.15.1 \
     samtools sort \
         -@ ${task_cpus} \
         -O bam \


### PR DESCRIPTION
I made a bash script to try testing `samtools sort` memory usage.  After I get it working on A-mini, I will test out on a larger bam file.

@tyamaguchi-ucla, do you know how I can profile the time and memory usage when submitting a job using `sbatch`?  

I have `#SBATCH --profile=Task` in the header, which is [supposed](https://support.nesi.org.nz/hc/en-gb/articles/360000810616-Slurm-Native-Profiling) to output runtime and memory usage info, however, none of this info appears in the `.error` and `.out` files. 

Alternatively, I could test the entire pipeline and the nextflow process logs should give me info about memory and time usage, but I was thinking it would be quicker to just run samtools sort in a bash script.  Thoughts?