### PR TITLE
optimize #CPUs for run_merge_SAMtools

### DIFF
--- a/config/F16.config
+++ b/config/F16.config
@@ -19,6 +19,7 @@ process {
         }
     withName: run_merge_SAMtools {
         cpus = 8
+        memory = 2.GB
         }
     withName: run_MarkDuplicate_Picard {
         cpus = 1

--- a/config/F32.config
+++ b/config/F32.config
@@ -19,6 +19,7 @@ process {
         }
     withName: run_merge_SAMtools {
         cpus = 12
+        memory = 2.GB        
         }
     withName: run_MarkDuplicate_Picard {
         cpus = 1

--- a/config/F72.config
+++ b/config/F72.config
@@ -19,6 +19,7 @@ process {
         }
     withName: run_merge_SAMtools {
         cpus = 12
+        memory = 2.GB
         }
     withName: run_MarkDuplicate_Picard {
         cpus = 1

--- a/config/M64.config
+++ b/config/M64.config
@@ -19,6 +19,7 @@ process {
         }
     withName: run_merge_SAMtools {
         cpus = 12
+        memory = 2.GB
         }
     withName: run_MarkDuplicate_Picard {
         cpus = 1


### PR DESCRIPTION
# Description

* optimize #CPUs for run_merge_SAMtools
* remove memory restriction of 10 Gb from `run_sort_SAMtools`: this was causing memory errors when testing on `/hot/software/pipeline/pipeline-align-DNA/Nextflow/development/input/CGBSTRIX_example.csv`

### To do

- [x] test on HISAT2 ?
- [x] after selecting the optimal number of CPUs, then determine the memory by testing on: `/hot/software/pipeline/pipeline-align-DNA/Nextflow/development/input/CPCG0196-B1.csv`

### Closes #218 

## Testing Results

### CGBSTRIX

View testing report here: 
[2022-07-19-samtools_merge_cpus_runtime.html.zip](https://github.com/uclahs-cds/pipeline-align-DNA/files/9143078/2022-07-19-samtools_merge_cpus_runtime.html.zip)

root path = `/hot/software/pipeline/pipeline-align-DNA/Nextflow/development/unreleased/jarbet-samtools-merge-cpus-mem/`

- BWA-MEM2
	- submission script: `./testing_cpus_BWA-MEM2.sh`
	- sample:    CGBSTRIX000001
	- input csv: `/hot/software/pipeline/pipeline-align-DNA/Nextflow/development/input/CGBSTRIX_example.csv`
	- config:    `./BWA-MEM2-cpus.config`
	- output:    `./R/2022-07-19-samtools_merge_cpus_runtime.html`
- HISAT2
        - submission script: `./testing_cpus_HISAT2.sh`
        - sample:    CGBSTRIX000001
	- input csv: `/hot/software/pipeline/pipeline-align-DNA/Nextflow/development/input/CGBSTRIX_example.csv`
	- config:    `./HISAT2-cpus.config`
	- output:    `./R/2022-07-19-samtools_merge_cpus_runtime.html`

### CPCG0196-B1

I forgot to update the output path in the config files so the output was saved on a different branch, but I copied over the log folder to this branch.  I can rerun if needed (took ~ 9 hours). 

- BWA-MEM2
    - submission script: `./testing_CPCG0196-B1.sh`
    - config: `./BWA-MEM2.config`
    - output: `/hot/software/pipeline/pipeline-align-DNA/Nextflow/development/unreleased/jarbet-samtools-merge-cpus-mem/align-DNA-8.0.0/CPCG0196-B1/log-align-DNA-8.0.0-20220721T194452Z/nextflow-log/report.html.1`
    - **peak_vmem: 1.069 GB**
    - peak_rss = 116.719 MB

- HISAT2
    - submission script: `./testing_CPCG0196-B1.sh`
    - config: `./BWA-MEM2-HISAT2.config`
    - output: `/hot/software/pipeline/pipeline-align-DNA/Nextflow/development/unreleased/jarbet-samtools-merge-cpus-mem/align-DNA-8.0.0/CPCG0196-B1/log-align-DNA-8.0.0-20220721T194452Z/nextflow-log/report.html`
    - **peak_vmem: 1.077 GB**
    - peak_rss = 140.121 MB
 


# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] I have reviewed the [Nextflow pipeline standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=Nextflow+pipeline+standardization).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].
  
- [X] I have set up the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request, or the branch protection rule has already been set up.

- [X] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [X] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [ ] I have tested the pipeline on at least one A-mini sample with aligner setting to `BWA-MEM2`, `HISAT2`, and both. The paths to the test config files and output directories were attached in the [Testing Results](#testing-results) section.
