### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/pipeline-release.yaml
+++ b/.github/workflows/pipeline-release.yaml
@@ -1,0 +1,14 @@
+---
+on:
+  push:
+    tags: "v*"
+  release:
+    types: [published]
+
+jobs:
+  add_release_asset:
+    runs-on: ubuntu-latest
+    name: A job to add a release asset with submodules
+    steps:
+      - id: release-asset
+        uses: ucla-cds/tool-Nextflow-action/add-source-with-submodules@v1.0.0-rc.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Update registered output function
 
 ### Added
+- Release workflow
 
 ## [8.1.0] - 2022-08-01
 ### Changed


### PR DESCRIPTION
Adding test workflow to run on release and include source code with submodules as an asset.

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] I have reviewed the [Nextflow pipeline standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=Nextflow+pipeline+standardization).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].
  
- [X] I have set up the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request, or the branch protection rule has already been set up.

- [X] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [X] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [ ] I have tested the pipeline on at least one A-mini sample with aligner setting to `BWA-MEM2`, `HISAT2`, and both. The paths to the test config files and output directories were attached in the [Testing Results](#testing-results) section.
