### PR TITLE
Group submodules with non-standard names

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,4 +13,4 @@ updates:
           - "*/pipeline-Nextflow-config"
           - "*/pipeline-Nextflow-module"
           - "*/nextflow-config"
-          - "*/nextflow-module"
+          - "*/nextflow-modules"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,5 @@ updates:
         patterns:
           - "*/pipeline-Nextflow-config"
           - "*/pipeline-Nextflow-module"
+          - "*/nextflow-config"
+          - "*/nextflow-module"


### PR DESCRIPTION
# Description
#322 didn't take because this pipeline renamed the submodules from `pipeline-Nextflow-*` to `nextflow-*`. This PR accounts for those custom names.