### PR TITLE
Add methods setup process afterscript

### DIFF
--- a/config/methods.config
+++ b/config/methods.config
@@ -209,6 +209,7 @@ methods {
 
     setup = {
         methods.set_params_from_input()
+	methods.setup_process_afterscript()
         schema.load_custom_types("${projectDir}/config/custom_schema_types.config")
         schema.validate()
         methods.set_output_dir()

--- a/module/align_DNA_BWA_MEM2.nf
+++ b/module/align_DNA_BWA_MEM2.nf
@@ -32,10 +32,8 @@ process align_DNA_BWA_MEM2 {
       pattern: "*.bam",
       mode: 'copy'
 
-   publishDir path: "${params.log_output_dir}/process-log/${params.bwa_version}/${task.process.split(':')[1].replace('_', '-')}",
-      pattern: ".command.*",
-      mode: "copy",
-      saveAs: { "${library}/${lane}/log${file(it).getName()}" }
+   ext log_dir: { "${params.bwa_version}/${task.process.split(':')[1].replace('_', '-')}" }
+   ext log_dir_suffix: { "/${library}/${lane}" }
 
    // use "each" so the the reference files are passed through for each fastq pair alignment
    input:
@@ -54,7 +52,6 @@ process align_DNA_BWA_MEM2 {
       tuple val(library),
          val(lane),
          path("${lane_level_bam}"), emit: bam
-      path(".command.*")
 
    script:
 

--- a/module/align_DNA_HISAT2.nf
+++ b/module/align_DNA_HISAT2.nf
@@ -32,10 +32,8 @@ process align_DNA_HISAT2 {
       pattern: "*.bam",
       mode: 'copy'
 
-   publishDir path: "${params.log_output_dir}/process-log/${params.hisat2_version}/${task.process.split(':')[1].replace('_', '-')}",
-      pattern: ".command.*",
-      mode: "copy",
-      saveAs: { "${library}/${lane}/log${file(it).getName()}" }
+   ext log_dir: { "${params.hisat2_version}/${task.process.split(':')[1].replace('_', '-')}" }
+   ext log_dir_suffix: { "/${library}/${lane}" }
 
    // use "each" so the the reference files are passed through for each fastq pair alignment
    input:
@@ -54,7 +52,6 @@ process align_DNA_HISAT2 {
       tuple val(library),
          val(lane),
          path("${lane_level_bam}"), emit: bam
-      path(".command.*")
 
    script:
 

--- a/test/configtest-F16.json
+++ b/test/configtest-F16.json
@@ -165,6 +165,12 @@
       "work_dir": "/scratch/8543"
     },
     "process": {
+      "afterScript": {
+        "1": "",
+        "2": "",
+        "3": "",
+        "closure": ""
+      },
       "cache": true,
       "commonRetryCodes": [
         "104",
@@ -194,6 +200,21 @@
         "closure": "terminate"
       },
       "executor": "local",
+      "ext": {
+        "capture_logs": true,
+        "commonAfterScript": {
+          "1": "",
+          "2": "",
+          "3": "",
+          "closure": ""
+        },
+        "log_dir": {
+          "1": "ext",
+          "2": "ext",
+          "3": "ext",
+          "closure": "ext"
+        }
+      },
       "maxRetries": "1",
       "memory": "31 GB",
       "withLabel:process_high": {


### PR DESCRIPTION
# Description

### Closes #321 

## Testing Results

- NFTest
  - input:
     sample_id: a_mini_n2_spark
     input_csv: /hot/software/pipeline/pipeline-align-DNA/Nextflow/development/input/csv/a_mini_n2.csv
     reference_fasta_bwa: /hot/ref/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/index/genome.fa
     reference_fasta_index_files_bwa: /hot/ref/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/index/genome.fa.*
     reference_fasta_hisat2: /hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta
     reference_fasta_index_files_hisat2: /hot/ref/tool-specific-input/HISAT2-2.2.1/GRCh38-BI-20160721/index/Homo_sapiens_assembly38.*.ht2

  - output:
     work_dir: /scratch/185380
     output_dir: /hot/software/pipeline/pipeline-align-DNA/Nextflow/development/unreleased/jsalmingo-use-methods-setup-process-afterscript/a_mini_n2-spark
     output_dir_base_bwa: /hot/software/pipeline/pipeline-align-DNA/Nextflow/development/unreleased/jsalmingo-use-methods-setup-process-afterscript/a_mini_n2-spark/align-DNA-10.1.0/a_mini_n2_spark
     output_dir_base_hisat2: /hot/software/pipeline/pipeline-align-DNA/Nextflow/development/unreleased/jsalmingo-use-methods-setup-process-afterscript/a_mini_n2-spark/align-DNA-10.1.0/a_mini_n2_spark
     log_output_dir_bwa: /hot/software/pipeline/pipeline-align-DNA/Nextflow/development/unreleased/jsalmingo-use-methods-setup-process-afterscript/a_mini_n2-spark/align-DNA-10.1.0/a_mini_n2_spark/log-align-DNA-10.1.0-20240625T211311Z/
     log_output_dir_hisat2: /hot/software/pipeline/pipeline-align-DNA/Nextflow/development/unreleased/jsalmingo-use-methods-setup-process-afterscript/a_mini_n2-spark/align-DNA-10.1.0/a_mini_n2_spark/log-align-DNA-10.1.0-20240625T211311Z/


# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].
  
- [X] I have set up the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request, or the branch protection rule has already been set up.

- [X] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [X] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [X] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [X] I have tested the pipeline on at least one A-mini sample with aligner setting to `BWA-MEM2`, `HISAT2`, and both. The paths to the test config files and output directories were attached in the [Testing Results](#testing-results) section.
