### PR TITLE
Add method to dump params object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Update Nextflow configuration test workflows
 - Update README.md to match template
 
+### Added
+- Add `params` object dump
+
 ## [10.0.0] - 2024-03-29
 ### Added
 - Add Action to generate documentation in GitHub Pages

--- a/config/methods.config
+++ b/config/methods.config
@@ -2,6 +2,7 @@ includeConfig "../external/nextflow-config/config/csv/csv_parser.config"
 includeConfig "../external/nextflow-config/config/methods/common_methods.config"
 includeConfig "../external/nextflow-config/config/retry/retry.config"
 includeConfig "../external/nextflow-config/config/schema/schema.config"
+includeConfig "../external/nextflow-config/config/store_object_as_json/store_object_as_json.config"
 
 methods {
     check_aligner = {
@@ -218,6 +219,7 @@ methods {
         methods.check_aligner()
         methods.set_resources_allocation()
 	methods.setup_docker_cpus()
+	json_extractor.store_object_as_json(params, new File("${params.log_output_dir}/params.json"))
         retry.setup_retry()
         }
     }

--- a/config/methods.config
+++ b/config/methods.config
@@ -219,7 +219,7 @@ methods {
         methods.check_aligner()
         methods.set_resources_allocation()
 	methods.setup_docker_cpus()
-	json_extractor.store_object_as_json(params, new File("${params.log_output_dir}/params.json"))
+	json_extractor.store_object_as_json(params, new File("${params.log_output_dir}/nextflow-log/params.json"))
         retry.setup_retry()
         }
     }


### PR DESCRIPTION
# Description
<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Adds the method to dump the `params` object to the log directory.

## Testing Results
NFTest

    input:
    sample_id: a_mini_n2_spark
    input_csv: /hot/software/pipeline/pipeline-align-DNA/Nextflow/development/input/csv/a_mini_n2.csv
    reference_fasta_bwa: /hot/ref/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/index/genome.fa
    reference_fasta_index_files_bwa: /hot/ref/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/index/genome.fa.*
    reference_fasta_hisat2: /hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta
    reference_fasta_index_files_hisat2: /hot/ref/tool-specific-input/HISAT2-2.2.1/GRCh38-BI-20160721/index/Homo_sapiens_assembly38.*.ht2

    output:
    work_dir: /scratch/203433
    output_dir: /hot/software/pipeline/pipeline-align-DNA/Nextflow/development/unreleased/jsalmingo-add-param-dump/a_mini_n2-spark
    output_dir_base_bwa: /hot/software/pipeline/pipeline-align-DNA/Nextflow/development/unreleased/jsalmingo-add-param-dump/a_mini_n2-spark/align-DNA-10.1.0/a_mini_n2_spark
    output_dir_base_hisat2: /hot/software/pipeline/pipeline-align-DNA/Nextflow/development/unreleased/jsalmingo-add-param-dump/a_mini_n2-spark/align-DNA-10.1.0/a_mini_n2_spark
    log_output_dir_bwa: /hot/software/pipeline/pipeline-align-DNA/Nextflow/development/unreleased/jsalmingo-add-param-dump/a_mini_n2-spark/align-DNA-10.1.0/a_mini_n2_spark/log-align-DNA-10.1.0-20240805T185700Z/
    log_output_dir_hisat2: /hot/software/pipeline/pipeline-align-DNA/Nextflow/development/unreleased/jsalmingo-use-methods-setup-process-afterscript/a_mini_n2-spark/align-DNA-10.1.0/a_mini_n2_spark/log-align-DNA-10.1.0-20240805T185700Z/


# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].
  
- [X] I have set up the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request, or the branch protection rule has already been set up.

- [X] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [X] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [X] I have tested the pipeline on at least one A-mini sample with aligner setting to `BWA-MEM2`, `HISAT2`, and both. The paths to the test config files and output directories were attached in the [Testing Results](#testing-results) section.
