### PR TITLE
Update cluster reference paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ See the following command for example:
 python path/to/pipeline-align-DNA/script/write_dna_align_config_file.py \
 	/my/path/to/sample_name.csv \
 	bwa-mem2 \
-	/hot/ref/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/index/genome.fa \
+	/hot/resource/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/index/genome.fa \
 	/my/path/to/output_directory \
 	/my/path/to/temp_directory \
 	--save_intermediate_files \

--- a/test/a_mini_n2-picard.config
+++ b/test/a_mini_n2-picard.config
@@ -11,11 +11,11 @@ params {
     dataset_id = "0000000"
 
     // BWA-MEM2 files
-    reference_fasta_bwa = "/hot/ref/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/index/genome.fa"
+    reference_fasta_bwa = "/hot/resource/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/index/genome.fa"
 
     // HISAT2 files
-    reference_fasta_hisat2 = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
-    hisat2_index_prefix = "/hot/ref/tool-specific-input/HISAT2-2.2.1/GRCh38-BI-20160721/index/Homo_sapiens_assembly38"
+    reference_fasta_hisat2 = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    hisat2_index_prefix = "/hot/resource/tool-specific-input/HISAT2-2.2.1/GRCh38-BI-20160721/index/Homo_sapiens_assembly38"
 
     // select aligner/s in list format (Current Options: BWA-MEM2, HISAT2)
     aligner = ["BWA-MEM2", "HISAT2"]

--- a/test/a_mini_n2-picard_yaml.config
+++ b/test/a_mini_n2-picard_yaml.config
@@ -10,11 +10,11 @@ params {
     dataset_id = "0000000"
 
     // BWA-MEM2 files
-    reference_fasta_bwa = "/hot/ref/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/index/genome.fa"
+    reference_fasta_bwa = "/hot/resource/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/index/genome.fa"
 
     // HISAT2 files
-    reference_fasta_hisat2 = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
-    hisat2_index_prefix = "/hot/ref/tool-specific-input/HISAT2-2.2.1/GRCh38-BI-20160721/index/Homo_sapiens_assembly38"
+    reference_fasta_hisat2 = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    hisat2_index_prefix = "/hot/resource/tool-specific-input/HISAT2-2.2.1/GRCh38-BI-20160721/index/Homo_sapiens_assembly38"
 
     // select aligner/s in list format (Current Options: BWA-MEM2, HISAT2)
     aligner = ["BWA-MEM2", "HISAT2"]

--- a/test/a_mini_n2-spark.config
+++ b/test/a_mini_n2-spark.config
@@ -11,11 +11,11 @@ params {
     dataset_id = "0000000"
 
     // BWA-MEM2 files
-    reference_fasta_bwa = "/hot/ref/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/index/genome.fa"
+    reference_fasta_bwa = "/hot/resource/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/index/genome.fa"
 
     // HISAT2 files
-    reference_fasta_hisat2 = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
-    hisat2_index_prefix = "/hot/ref/tool-specific-input/HISAT2-2.2.1/GRCh38-BI-20160721/index/Homo_sapiens_assembly38"
+    reference_fasta_hisat2 = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    hisat2_index_prefix = "/hot/resource/tool-specific-input/HISAT2-2.2.1/GRCh38-BI-20160721/index/Homo_sapiens_assembly38"
 
     // select aligner/s in list format (Current Options: BWA-MEM2, HISAT2)
     aligner = ["BWA-MEM2", "HISAT2"]

--- a/test/configtest-F16.json
+++ b/test/configtest-F16.json
@@ -64,7 +64,7 @@
       "enable_spark": false,
       "gatk_command_mem_diff": "5 GB",
       "hisat2_and_samtools_version": "2.2.1_samtools-1.17",
-      "hisat2_index_prefix": "/hot/ref/tool-specific-input/HISAT2-2.2.1/GRCh38-BI-20160721/index/Homo_sapiens_assembly38",
+      "hisat2_index_prefix": "/hot/resource/tool-specific-input/HISAT2-2.2.1/GRCh38-BI-20160721/index/Homo_sapiens_assembly38",
       "hisat2_version": "HISAT2-2.2.1",
       "input": {
         "FASTQ": [
@@ -149,10 +149,10 @@
           "memory": "1 GB"
         }
       },
-      "reference_fasta_bwa": "/hot/ref/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/index/genome.fa",
-      "reference_fasta_hisat2": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
-      "reference_fasta_index_files_bwa": "/hot/ref/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/index/genome.fa.*",
-      "reference_fasta_index_files_hisat2": "/hot/ref/tool-specific-input/HISAT2-2.2.1/GRCh38-BI-20160721/index/Homo_sapiens_assembly38.*.ht2",
+      "reference_fasta_bwa": "/hot/resource/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/index/genome.fa",
+      "reference_fasta_hisat2": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+      "reference_fasta_index_files_bwa": "/hot/resource/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/index/genome.fa.*",
+      "reference_fasta_index_files_hisat2": "/hot/resource/tool-specific-input/HISAT2-2.2.1/GRCh38-BI-20160721/index/Homo_sapiens_assembly38.*.ht2",
       "sample_id": "a_mini_n2_picard",
       "save_intermediate_files": false,
       "spark_metrics": false,


### PR DESCRIPTION
This PR updates reference paths that were renamed during the most recent cluster downtime.

I was specifically looking for single lines containing one (or more) of the following keys, so I missed any paths split across multiple lines.

| Search String                                                  |
|----------------------------------------------------------------|
| `/hot/ref/`                                                    |
| `/hot/ref/cohort/TCGA/CCG-AIM/`                                |
| `/hot/ref/cohort/TCGA/PanCanAtlas/`                            |
| `/hot/ref/database/1000Genomes/`                               |
| `/hot/ref/database/GDC-34.0 `                                  |
| `/hot/ref/database/GDC-34.0/`                                  |
| `/hot/ref/database/PCAWG/`                                     |
| `/hot/ref/database/ProstateTumor/Boutros-Yamaguchi-PRAD-CPCG/` |
| `/hot/ref/reference/`                                          |
| `/hot/resource/SMC-HET/`                                       |

A table of updated filepaths and whether or not they resolve to a file is included below. Where the original paths still exist due to symlinks I verified that they resolve to the same file as the updated path.

| Original                                                                                           |                    | Updated                                                                                                 |                    |
|----------------------------------------------------------------------------------------------------|--------------------|---------------------------------------------------------------------------------------------------------|--------------------|
| `/hot/ref/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/index/genome.fa`                   | :white_check_mark: | `/hot/resource/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/index/genome.fa`                   | :white_check_mark: |
| `/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta`                              | :white_check_mark: | `/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta`                       | :white_check_mark: |
| `/hot/ref/tool-specific-input/HISAT2-2.2.1/GRCh38-BI-20160721/index/Homo_sapiens_assembly38`       | (Parent folders match)                | `/hot/resource/tool-specific-input/HISAT2-2.2.1/GRCh38-BI-20160721/index/Homo_sapiens_assembly38`       | (Parent folders match)                |
| `/hot/ref/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/index/genome.fa.*`                 | (Parent folders match)                | `/hot/resource/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/index/genome.fa.*`                 | (Parent folders match)                |
| `/hot/ref/tool-specific-input/HISAT2-2.2.1/GRCh38-BI-20160721/index/Homo_sapiens_assembly38.*.ht2` | (Parent folders match)                | `/hot/resource/tool-specific-input/HISAT2-2.2.1/GRCh38-BI-20160721/index/Homo_sapiens_assembly38.*.ht2` | (Parent folders match)                |
